### PR TITLE
fix: upgrade Next.js to 15.1.10 (CVE-2025-55182)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "next build"
   },
   "dependencies": {
-    "next": "15.1.9",
+    "next": "15.1.10",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       next:
-        specifier: 15.1.9
-        version: 15.1.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 15.1.10
+        version: 15.1.10(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react:
         specifier: ^19.0.0
         version: 19.0.0
@@ -141,8 +141,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/env@15.1.9':
-    resolution: {integrity: sha512-Te1wbiJ//I40T7UePOUG8QBwh+VVMCc0OTuqesOcD3849TVOVOyX4Hdrkx7wcpLpy/LOABIcGyLX5P/SzzXhFA==}
+  '@next/env@15.1.10':
+    resolution: {integrity: sha512-FA4AHiPh0RzXfQn1C7mp6G8KqREgiy+6mE06McrzeT8w1nYvmbLsxBAPZAg8gqDAk4XZKHC7siAkQc2TDRJzfg==}
 
   '@next/swc-darwin-arm64@15.1.9':
     resolution: {integrity: sha512-sQF6MfW4nk0PwMYYq8xNgqyxZJGIJV16QqNDgaZ5ze9YoVzm4/YNx17X0exZudayjL9PF0/5RGffDtzXapch0Q==}
@@ -248,8 +248,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  next@15.1.9:
-    resolution: {integrity: sha512-OoQpDPV2i3o5Hnn46nz2x6fzdFxFO+JsU4ZES12z65/feMjPHKKHLDVQ2NuEvTaXTRisix/G5+6hyTkwK329kA==}
+  next@15.1.10:
+    resolution: {integrity: sha512-t+PruqHTsuSQZpl7H3hzxcJD5NR13JHfZU23z9QNEFC+g/z9QiAp52vykL5r1Tq3m0IrxnaXfjJSCMUAk6FDFQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -414,7 +414,7 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
-  '@next/env@15.1.9': {}
+  '@next/env@15.1.10': {}
 
   '@next/swc-darwin-arm64@15.1.9':
     optional: true
@@ -496,9 +496,9 @@ snapshots:
 
   nanoid@3.3.8: {}
 
-  next@15.1.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.1.10(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@next/env': 15.1.9
+      '@next/env': 15.1.10
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0


### PR DESCRIPTION
This upgrade fixes CVE-2025-55182, a React Server Components RCE vulnerability.